### PR TITLE
DCOS-46465: update rxjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9358,12 +9358,12 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.10",
-      "resolved": "http://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
-      "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "rxjs-marbles": {
@@ -10468,10 +10468,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -10659,6 +10658,12 @@
           }
         }
       }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3422,7 +3422,6 @@
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
       "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
-      "dev": true,
       "requires": {
         "iterall": "^1.2.2"
       }
@@ -4208,8 +4207,7 @@
     "iterall": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
-      "dev": true
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "java-properties": {
       "version": "0.2.10",
@@ -9054,9 +9052,12 @@
       }
     },
     "reactive-graphql": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reactive-graphql/-/reactive-graphql-1.0.0.tgz",
-      "integrity": "sha512-wDVX/Yek1HhXFBZANLllS+mIjlem7ICz50Ks1n0sHsIqJr2OkTz/L6TuAHFAstjR9EMuTQ0YP8nmirkLosQ9Mg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reactive-graphql/-/reactive-graphql-2.0.0.tgz",
+      "integrity": "sha512-1lh4RQ2TgQKVzGMRkstZNkyg8bKeQyf8FxudHZ0W9RO/ZFnPsX2vLIDqS1hnBettCfwKZjGVfQCD1R3wXGi1yQ==",
+      "requires": {
+        "graphql": "^14.0.2"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "graphql-tag": "2.8.0",
     "graphql-tools": "4.0.3",
     "recompose": "0.26.0",
-    "rxjs": "6.6.3"
+    "rxjs": "6.3.3"
   },
   "devDependencies": {
     "@types/graphql": "14.0.2",
@@ -41,7 +41,7 @@
     "typescript": "3.2.1"
   },
   "dependencies": {
-    "reactive-graphql": "^1.0.0",
+    "reactive-graphql": "^2.0.0",
     "symbol-observable": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "graphql-tag": "2.8.0",
     "graphql-tools": "4.0.3",
     "recompose": "0.26.0",
-    "rxjs": "5.5.10"
+    "rxjs": "6.6.3"
   },
   "devDependencies": {
     "@types/graphql": "14.0.2",
@@ -34,13 +34,14 @@
     "react": "16.6.3",
     "recompose": "0.26.0",
     "rimraf": "2.6.2",
-    "rxjs": "5.5.10",
+    "rxjs": "6.3.3",
     "rxjs-marbles": "2.3.1",
     "semantic-release": "15.12.4",
     "ts-jest": "23.10.5",
     "typescript": "3.2.1"
   },
   "dependencies": {
-    "reactive-graphql": "^1.0.0"
+    "reactive-graphql": "^1.0.0",
+    "symbol-observable": "^1.2.0"
   }
 }

--- a/src/recomposeRx.ts
+++ b/src/recomposeRx.ts
@@ -1,9 +1,15 @@
+import "symbol-observable";
 import {
   componentFromStreamWithConfig,
-  createEventHandlerWithConfig
+  createEventHandlerWithConfig,
+  Subscribable
 } from "recompose";
+import { from } from "rxjs";
 
-import rxjsConfig from "recompose/rxjsObservableConfig";
+const rxjsConfig = {
+  fromESObservable: from as (<T>(observable: Subscribable<T>) => any),
+  toESObservable: stream => stream
+};
 
 export const createEventHandler = createEventHandlerWithConfig(rxjsConfig);
 export const componentFromStream = componentFromStreamWithConfig(rxjsConfig);


### PR DESCRIPTION
Update rxjs to latest version @6.3.3. Breaking change: consumers of this package need to be using rxjs 6.x.

TODO: 
- [x] Update reactive-graphql dependency once updated to rxjs 6 (blocked by mesosphere/reactive-graphql#2)

Closes DCOS-46465.